### PR TITLE
Fix parse error when checking version

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -91,4 +91,4 @@ sslverify=${sslverify}" > "${repo_file}"
 [ -n "${repository_username}" ] && echo "username=${repository_username}" >> "${repo_file}"
 [ -n "${repository_password}" ] && echo "password=${repository_password}" >> "${repo_file}"
 
-dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | jq 'tostring | [{version: .}]' >&3
+dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | xargs printf '{"version": "%s"}' >&3

--- a/assets/check
+++ b/assets/check
@@ -90,4 +90,4 @@ sslverify=${sslverify}" > "${repo_file}"
 [ -n "${repository_username}" ] && echo "username=${repository_username}" >> "${repo_file}"
 [ -n "${repository_password}" ] && echo "password=${repository_password}" >> "${repo_file}"
 
-dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | xargs printf '[{"version": "%s"}]' >&3
+dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | jq -c -M 'tostring | [{version: .}]' >&3

--- a/assets/check
+++ b/assets/check
@@ -82,7 +82,6 @@ readonly repo_file='/etc/yum.repos.d/Resource-Repository.repo'
 echo -e "[resource-repository]
 name=Resource
 baseurl=${repository_url}
-enabled=
 gpgcheck=${gpg_check}
 repo_gpgcheck=${gpg_check}
 sslverify=${sslverify}" > "${repo_file}"

--- a/assets/check
+++ b/assets/check
@@ -90,4 +90,4 @@ sslverify=${sslverify}" > "${repo_file}"
 [ -n "${repository_username}" ] && echo "username=${repository_username}" >> "${repo_file}"
 [ -n "${repository_password}" ] && echo "password=${repository_password}" >> "${repo_file}"
 
-dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | xargs printf '{"version": "%s"}' >&3
+dnf info "${package}" --forcearch "${architecture}" | grep Version | awk '{ print $3 }' | xargs printf '[{"version": "%s"}]' >&3

--- a/assets/in
+++ b/assets/in
@@ -89,7 +89,6 @@ readonly repo_file='/etc/yum.repos.d/Resource-Repository.repo'
 echo -e "[resource-repository]
 name=Resource
 baseurl=${repository_url}
-enabled=
 gpgcheck=${gpg_check}
 repo_gpgcheck=${gpg_check}
 sslverify=${sslverify}" > "${repo_file}"


### PR DESCRIPTION
There is no need to have jq used here. Using jq here on certain versions (2.0.4) results in a parser error.